### PR TITLE
Handle no invitation_key on connections, and time format change

### DIFF
--- a/askar_tools/tenant_importer.py
+++ b/askar_tools/tenant_importer.py
@@ -147,14 +147,14 @@ class TenantImporter:
                 category="forward_route",
                 name=str(uuid.uuid4()),
                 value_json={
-                    "recipient_key": connection.value_json["invitation_key"] if "invitation_key" in connection.value_json else "",
+                    "recipient_key": connection.value_json.get("invitation_key", ""),
                     "wallet_id": wallet_id,
                     "created_at": current_time,
                     "updated_at": current_time,
                     "connection_id": None,
                 },
                 tags={
-                    "recipient_key": connection.value_json["invitation_key"] if "invitation_key" in connection.value_json else "",
+                    "recipient_key": connection.value_json.get("invitation_key", ""),
                     "role": "server",
                     "wallet_id": wallet_id,
                 },
@@ -218,7 +218,7 @@ class TenantImporter:
             async with admin_store.transaction() as admin_txn:
                 wallet_id = str(uuid.uuid4())
                 utc_time = datetime.now(timezone.utc)
-                current_time = utc_time.replace(tzinfo=None).isoformat(timespec='microseconds') + "Z"
+                current_time = utc_time.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
                 await self._create_tenant(
                     wallet_id=wallet_id,
                     admin_txn=admin_txn,

--- a/askar_tools/tenant_importer.py
+++ b/askar_tools/tenant_importer.py
@@ -1,7 +1,7 @@
 """This module contains the Tenant Importer class."""
 
-import time
 import uuid
+from datetime import datetime,timezone
 
 from aries_askar import Store
 
@@ -147,14 +147,14 @@ class TenantImporter:
                 category="forward_route",
                 name=str(uuid.uuid4()),
                 value_json={
-                    "recipient_key": connection.value_json["invitation_key"],
+                    "recipient_key": connection.value_json["invitation_key"] if "invitation_key" in connection.value_json else "",
                     "wallet_id": wallet_id,
                     "created_at": current_time,
                     "updated_at": current_time,
                     "connection_id": None,
                 },
                 tags={
-                    "recipient_key": connection.value_json["invitation_key"],
+                    "recipient_key": connection.value_json["invitation_key"] if "invitation_key" in connection.value_json else "",
                     "role": "server",
                     "wallet_id": wallet_id,
                 },
@@ -217,7 +217,8 @@ class TenantImporter:
             )
             async with admin_store.transaction() as admin_txn:
                 wallet_id = str(uuid.uuid4())
-                current_time = time.time()
+                utc_time = datetime.now(timezone.utc)
+                current_time = utc_time.replace(tzinfo=None).isoformat(timespec='microseconds') + "Z"
                 await self._create_tenant(
                     wallet_id=wallet_id,
                     admin_txn=admin_txn,


### PR DESCRIPTION
These are tweaks to the import script in askar tools.

1)
For connections initiated via didexchange (`didexchange/create-request` with 1.0 or 1.1) in the resultant connections there is not an `invitation_key`, which causes an exception when copying over running the import script due to expecting that key/value.

Example of a didexchange create-request, and an OOB initiated invitation:

![image](https://github.com/user-attachments/assets/4f7d3dbd-ec7e-49b9-8a9c-91e0d24e5194)

So just conditionally include that in the `_create_forward_routes` function.

2)
Created and updated time for inserted records was using `time.time`.
![image](https://github.com/user-attachments/assets/443d1253-c49d-4158-9a0d-0cdbc9916f47) 

ACA-Py records use a format like
![image](https://github.com/user-attachments/assets/734298a7-e805-48dc-aeec-f286995290d0)
